### PR TITLE
Avoid NullPointerException

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/core/SPFSession.java
+++ b/resolver/src/main/java/org/apache/james/jspf/core/SPFSession.java
@@ -160,6 +160,10 @@ public class SPFSession implements MacroData {
      * @see org.apache.james.jspf.core.MacroData#getClientDomain()
      */
     public String getClientDomain() {
+        if (clientDomain == null) {
+            return "unknown";
+        }
+        
         return clientDomain;
     }
     


### PR DESCRIPTION
Stacktrace:

java.lang.NullPointerException
at org.xbill.DNS.Name.fromString(Name.java:301) ~[dnsjava-2.1.5.jar:2.1.5]
at org.xbill.DNS.Name.fromString(Name.java:319) ~[dnsjava-2.1.5.jar:2.1.5]
at org.apache.james.jspf.core.DNSRequest.(DNSRequest.java:52) ~[apache-jspf-resolver-1.0.0.jar:1.0.0]
at org.apache.james.jspf.terms.ExistsMechanism$ExpandedChecker.checkSPF(ExistsMechanism.java:53) ~[apache-jspf-resolver-1.0.0.jar:1.0.0]
at org.apache.james.jspf.executor.SynchronousSPFExecutor.execute(SynchronousSPFExecutor.java:54) [apache-jspf-resolver-1.0.0.jar:1.0.0]
at org.apache.james.jspf.impl.SPF.checkSPF(SPF.java:315) [apache-jspf-resolver-1.0.0.jar:1.0.0]

How to reproduce it:

String ipAddress = "8.8.8.8";
String mailFrom = "any@thecraigs.net";
String hostName = "8.8.8.8";

DefaultSPF spf = new DefaultSPF();
spf.checkSPF(ipAddress, mailFrom, hostName);

SPF record of thecraigs.net :

v=spf1 ip4:208.42.240.22 ip4:208.42.240.20 exists:_i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o} ?all